### PR TITLE
Major program structure changes and allows different geographical divisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Scripts to calculate phylodiversity and its distribution from BOLD DNA barcode data.
 
 ## Usage
-Call the PHP script from the PHP executable with a taxon name and optionally other arguments.
+Call the PHP script `phylodiv.php` from the PHP executable with a taxon name and optionally other arguments.
 
 E.g. `path/to/php phylodiv.php Hexactinellida 10 15 15 path/to/clustalw2 path/to/paup`
 

--- a/align.php
+++ b/align.php
@@ -1,0 +1,29 @@
+<?php
+
+function align($infile, $logfile) {
+    global $CLUSTAL_PATH;
+    
+    echo('Aligning sequences in ' . $infile . '...' . PHP_EOL);
+
+	$command = $CLUSTAL_PATH 
+	. ' -INFILE=' . $infile 
+	. ' -QUICKTREE -OUTORDER=INPUT -OUTPUT=NEXUS' 
+	. " 1>" . $logfile;
+	system($command);
+
+    // Check file has been output successfully
+    $outfile = preg_replace('/\.fas/i', '.nxs', $infile);
+    if (file_exists($outfile) && filesize($outfile)) {
+        return $outfile;
+    } else {
+        // diagnose from log file
+        $log = file_get_contents($logfile);
+        if (preg_match('/Only 1 sequence/i', $log)) {
+            echo('Only one sequence given, cannot align' . PHP_EOL);
+        }
+
+        return '';
+    }
+}
+
+?>

--- a/division_scheme.php
+++ b/division_scheme.php
@@ -1,0 +1,17 @@
+<?php
+
+// Returns a string representing the current geographical division scheme parameters
+function division_scheme() {
+    global $GEO_DIVISION_SCHEME, $GEO_DIVISION_SCHEMES;
+    global $LATITUDE_GRID_SIZE_DEG, $LONGITUDE_GRID_SIZE_DEG;
+
+    if ($GEO_DIVISION_SCHEME === $GEO_DIVISION_SCHEMES['COORDS']) {
+        return 'COORDS_' . $LATITUDE_GRID_SIZE_DEG . 'x' . $LONGITUDE_GRID_SIZE_DEG;
+    } 
+    else if ($GEO_DIVISION_SCHEME === $GEO_DIVISION_SCHEMES['COUNTRY']) {
+        return 'COUNTRY';
+    }
+    return '';
+}
+
+?>

--- a/geo_divide.php
+++ b/geo_divide.php
@@ -1,0 +1,130 @@
+<?php
+
+require_once __DIR__.DIRECTORY_SEPARATOR. 'taxsets_data_file.php';
+require_once __DIR__.DIRECTORY_SEPARATOR. 'sequence_file.php';
+require_once __DIR__.DIRECTORY_SEPARATOR. 'sequence_data_file.php';
+require_once __DIR__.DIRECTORY_SEPARATOR. 'get_geo_division.php';
+
+// Sorts the downloaded sequences for $taxon into taxsets depending on current division_scheme(),
+// and adds them as entries to taxsets_data_file($taxon), which is assumed to already exist with some entries.
+// Doesn't do a check if they're already in there, and will duplicate entries if they are.
+// Returns an array of the new geographical division names.
+function geo_divide($taxon) {
+    global $SEQUENCE_DATA_DELIMITER, $TAXSETS_DATA_DELIMITER, $TAXSET_DELIMITER;
+
+    if(!(file_exists($data_file = taxsets_data_file($taxon)))) { 
+        exit('Error: non-existent ' .$data_file. ' requested by geo_divide(' .$taxon. ')');
+    }
+    if(!(file_exists($sequence_file = sequence_file($taxon)))) {
+        exit('Error: non-existent ' .$sequence_file. ' requested by geo_divide(' .$taxon. ')');
+    }
+    if(!(file_exists($sequence_data_file = sequence_data_file($taxon)))) {
+        exit('Error: non-existent ' .$sequence_data_file. ' requested by geo_divide(' .$taxon. ')');
+    }
+
+    $sequence_index = 0;
+    $sequence_counts = array();
+    $taxsets = array();
+
+    $sequences_handle = fopen($sequence_file, 'r');
+    $sequence_data_handle = fopen($sequence_data_file, 'r');
+    $sequence_data_header = fgetcsv($sequence_data_handle, 0, $SEQUENCE_DATA_DELIMITER);
+    $fields = array_flip($sequence_data_header);
+    while($line = fgets($sequences_handle)) {
+        // only count header lines:
+        if ((trim($line))[0] != '>') { continue; }
+
+        $sequence_index++;
+
+        // Get the corresponding entry in $sequence_data_file (should most likely be the current line)
+        $read_whole_file = false;
+        $seq_data_index = 0;
+        do {
+            $sequence_data_entry = fgetcsv($sequence_data_handle, 0, $SEQUENCE_DATA_DELIMITER);
+            if ($sequence_data_entry) {
+                if ($sequence_data_entry[$fields['file']] != $sequence_file) {
+                    // echo ('wrong file'.PHP_EOL);
+                    // continue; 
+                } else {
+                    $seq_data_index = $sequence_data_entry[$fields['sequence_index']];
+                }
+            } else {
+                if ($read_whole_file) { break; }
+                else {
+                    // loop round to the beginning
+                    $read_whole_file = true;
+                    rewind($sequence_data_handle);
+                    // skip the header line
+                    fgets($sequence_data_handle);
+                }
+            }
+        } while ($seq_data_index != $sequence_index);
+        
+        if (!$sequence_data_entry) { continue; }
+
+        $loc = get_geo_division($sequence_data_entry, $sequence_data_header);
+        if ($loc) {
+            // Keep location-specific record of sequences stored
+            if(!isset($sequence_counts[$loc])) { $sequence_counts[$loc] = 0; }
+            $sequence_counts[$loc]++;
+
+            // Store the index in a location-specific taxset
+            if(!isset($taxsets[$loc])) { $taxsets[$loc] = ''; }
+            if ($sequence_counts[$loc] > 1) { $taxsets[$loc] .= $TAXSET_DELIMITER; }
+            $taxsets[$loc] .= $sequence_index;
+        }
+
+        // Update the user as this may take a while
+        if ($sequence_index % 500 == 0) {
+            echo('Sorted ' . $sequence_index . ' into locations...'.PHP_EOL);
+        }
+    } // end while loop
+    fclose($sequences_handle);
+    fclose($sequence_data_handle);
+
+    if ($sequence_index == 0) {
+        exit('Error: geo_divide('.$taxon.') requested empty sequence file ' . $sequence_file . PHP_EOL);
+    }
+
+    // Save data in a csv
+
+    // Get header
+    $taxsets_handle = fopen($data_file, 'r+');
+    $taxsets_header = fgetcsv($taxsets_handle, 0, $TAXSETS_DATA_DELIMITER);
+
+    // Jump to end
+    fseek($taxsets_handle, 0, SEEK_END);
+    
+    // Add each new taxset
+    foreach ($sequence_counts as $loc => $count)
+    {
+        $entry = array(
+            $taxon,
+            division_scheme(),
+            $loc,
+            $count,
+            $sequence_file,
+            $taxsets[$loc]
+        );
+
+        // Make sure fields are in the expected order
+        $entry_fields = array_flip(array(
+            field::TAXON,
+            field::DIVISION_SCHEME,
+            field::LOCATION,
+            field::COUNT,
+            field::FILE,
+            field::TAXSET
+        ));
+        $entry_shuffle = function ($col) use ($entry, $entry_fields) {
+            return $entry[$entry_fields[$col]]; };
+        $entry = array_map($entry_shuffle, $taxsets_header);
+
+        fputcsv($taxsets_handle, $entry, $TAXSETS_DATA_DELIMITER);
+    }
+    fclose($taxsets_handle);
+
+    return array_keys($taxsets);
+}
+
+?>

--- a/geo_divisions.php
+++ b/geo_divisions.php
@@ -1,0 +1,42 @@
+<?php
+
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'taxsets_data_file.php';
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'division_scheme.php';
+
+// Gets the names of stored location taxsets for a given taxon, where taxsets where formed using current settings.
+// Looks in taxsets_data_file($taxon) for entries with division_scheme = division_scheme(),
+// and returns an array of the values in column 'location'
+function geo_divisions($taxon) {
+    global $LATITUDE_GRID_SIZE_DEG, $LONGITUDE_GRID_SIZE_DEG;
+    global $TAXSETS_DATA_DELIMITER;
+
+    $data_file = taxsets_data_file($taxon);
+    if (!file_exists($data_file)) { 
+        exit('Error: non-existent ' .$data_file. ' requested by geo_divisions(' .$taxon. ')');
+    }
+
+    $handle = fopen($data_file, 'r');
+    $header = fgetcsv($handle, 0, $TAXSETS_DATA_DELIMITER);
+    $fields = array_flip($header);
+
+    if (!(in_array(field::DIVISION_SCHEME, $header) && in_array(field::LOCATION, $header)))
+    {
+        echo ('Bad data file format: missing column \'header\' or \'location\''.PHP_EOL);
+        return array();
+    }
+
+    $divisions = array();
+
+    while ($entry = fgetcsv($handle, 0, $TAXSETS_DATA_DELIMITER)) {
+
+        if ($entry[$fields[field::DIVISION_SCHEME]] != division_scheme()) { continue; }
+
+        if ($loc = $entry[$fields[field::LOCATION]]) {
+            array_push($divisions, $loc);
+        }
+    }
+
+    return $divisions;
+}
+
+?>

--- a/get_geo_division.php
+++ b/get_geo_division.php
@@ -1,0 +1,37 @@
+<?php
+
+// Returns a string encoding the location of the specimen represented by array $entry.
+// Expects $entry to be of same size as $fields, 
+// and $fields should be an array of strings describing the fields of $entry (ie, the table header).
+// The strings required in $fields depend on the current $GEO_DIVISION_SCHEME.
+// The output of this function for given input varies with division_scheme().
+function get_geo_division($entry, $fields) {
+    global $GEO_DIVISION_SCHEME, $GEO_DIVISION_SCHEMES;
+    global $LATITUDE_GRID_SIZE_DEG, $LONGITUDE_GRID_SIZE_DEG;
+
+    $col = array_flip($fields);
+
+    // Check location is present: either coordinates or country
+    $country = $lat = $lon = '';
+    if ($GEO_DIVISION_SCHEME === $GEO_DIVISION_SCHEMES['COORDS']) {
+        if (($lat = $entry[$col['lat']]) == '') { return false; }
+        if (($lon = $entry[$col['lon']]) == '') { return false; }
+
+        $lat_a = floor($lat / $LATITUDE_GRID_SIZE_DEG) * $LATITUDE_GRID_SIZE_DEG;
+		$lat_b = $lat_a + $LATITUDE_GRID_SIZE_DEG;
+		$grid_lat = $lat_a . 'to' . $lat_b;
+		$lon_a = floor($lon / $LONGITUDE_GRID_SIZE_DEG) * $LONGITUDE_GRID_SIZE_DEG;
+		$lon_b = $lon_a + $LONGITUDE_GRID_SIZE_DEG;
+		$grid_lon = $lon_a . 'to' . $lon_b;
+		return 'lat_' . $grid_lat . '_lon_' . $grid_lon;
+    } else if ($GEO_DIVISION_SCHEME === $GEO_DIVISION_SCHEMES['COUNTRY']) {
+        if (($country = $entry[$col['country']]) == '') { return false; }
+        return $country;
+    } else {
+        return false;
+    }
+}
+
+?>
+
+

--- a/get_sequences.php
+++ b/get_sequences.php
@@ -1,0 +1,175 @@
+<?php
+
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'sequence_file.php';
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'get_geo_division.php';
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'taxsets_data_file.php';
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'division_scheme.php';
+require_once __DIR__ .DIRECTORY_SEPARATOR. 'sequence_data_file.php';
+
+// Look for downloaded sequences of $marker for $taxon. If no taxsets_data_file is found,
+// download the sequences from BOLD, and store subsets of them by location in a new taxsets_data_file.
+// Return { DOWNLOAD_ATTEMPTED:bool, PATH:string }
+// where PATH is the path to the taxsets_data_file.
+// If download failed, return { true, false }.
+function get_sequences($taxon, $marker) {
+    global $SEQUENCE_DATA_DELIMITER;
+    global $TAXSETS_DATA_DELIMITER, $TAXSET_DELIMITER;
+
+    $BOLD_URL_PREFIX = 'http://www.boldsystems.org/index.php/API_Public/combined';
+    $SEQUENCE_SOURCE_FORMAT = 'tsv';
+    $SOURCE_DELIMITER = "\t";
+
+    // this array defines the columns which we want to keep locally as data about a sequence's location etc.
+    // Make sure to check the output from BOLD if there are any format changes; 
+    // otherwise, there will be fields missing from the saved data.
+    $KEEP_SOURCE_FIELDS = array(
+        'institution_storing',
+        'collection_event_id',
+        'collectiondate_start',
+        'collectiondate_end',
+        'collectiontime',
+        'collection_note',
+        'site_code',
+        'sampling_protocol',
+        'habitat',
+        'notes',
+        'lat',
+        'lon',
+        'coord_source',
+        'coord_accuracy',
+        'elev',
+        'depth',
+        'elev_accuracy',
+        'depth_accuracy',
+        'country',
+        'province_state',
+        'region',
+        'sector',
+        'exactsite'
+    );
+
+    $taxsets_data_file = taxsets_data_file($taxon);
+    if (file_exists($taxsets_data_file)) {
+        return array(false, $taxsets_data_file);
+    }
+
+    echo('Downloading sequences for ' . $taxon . PHP_EOL);
+
+    // Open stream handle
+    $bold_query = $BOLD_URL_PREFIX . '?'
+    . 'format=' . $SEQUENCE_SOURCE_FORMAT 
+    . '&marker=' . $marker 
+    . '&taxon=' . $taxon;	
+    $source_handle = fopen($bold_query, 'r');
+
+    // Get source header for indexing columns
+    $header = fgetcsv($source_handle, 0, $SOURCE_DELIMITER);
+    $fields = array_flip($header);
+
+    $sequence_file = sequence_file($taxon);
+    $sequence_cache_handle = fopen($sequence_file, 'w');
+    $sequence_counts = array();
+    $sequence_count_total = 0;
+    $taxsets = array();
+
+    $sequence_data_file = sequence_data_file($taxon);
+    $sequence_data_handle = fopen($sequence_data_file, 'w');
+    $sequence_data_header = $KEEP_SOURCE_FIELDS;
+    array_unshift($sequence_data_header, 'sequence_index', 'file');
+    fputcsv($sequence_data_handle, $sequence_data_header, $SEQUENCE_DATA_DELIMITER);
+
+    // Step through stream line by line
+    while ($entry = fgetcsv($source_handle, 0, $SOURCE_DELIMITER))
+    {
+        // Check marker is the one we want to use
+        if ($entry[$fields['markercode']] != $marker) { continue; }
+
+        // Make sequence header
+        if (($id = $entry[$fields['processid']]) == '') { continue; }
+        $id = preg_replace('/-/', '_', $id);
+        if (($species = $entry[$fields['species_name']]) != '') {
+            $sequence_header = preg_replace('~[-/ ]~', '_', $species) . '|' . $id;
+        } else if (($genus = $entry[$fields['genus_name']]) != '') {
+            $sequence_header = $genus . '_sp|' . $id;
+        } else {
+            $sequence_header = $id;
+        }
+        $sequence_header = '>' . $sequence_header;
+
+        // Get sequence and write to file after header
+        if (($seq = $entry[$fields['nucleotides']]) == '') { continue; }
+        fwrite($sequence_cache_handle, $sequence_header . PHP_EOL);
+        fwrite($sequence_cache_handle, $seq . PHP_EOL);
+
+        // Get the location of the sequence according to current geographical division scheme
+        $loc = get_geo_division($entry, $header);
+        if ($loc) { 
+            // Keep location-specific record of sequences stored
+            if(!isset($sequence_counts[$loc])) { $sequence_counts[$loc] = 0; }
+            $sequence_counts[$loc]++;
+
+            // Store the index in a location-specific taxset
+            if(!isset($taxsets[$loc])) { $taxsets[$loc] = ''; }
+            if ($sequence_counts[$loc] > 1) { $taxsets[$loc] .= $TAXSET_DELIMITER; }
+            $taxsets[$loc] .= $sequence_count_total;
+        }
+
+        // update the user for big downloads
+        $sequence_count_total++;
+        if ($sequence_count_total % 250 == 0) {
+            echo("Saved " . $sequence_count_total . ' sequences...' . PHP_EOL);
+        }
+
+        // Store the full location etc metadata for the sequence locally, 
+        // so we can use a different geographical division scheme in future.
+        $entry_subset = function ($col) use ($fields, $entry) {
+            if (key_exists($col, $fields)) { return $entry[$fields[$col]]; }
+            else { return ''; } };
+        $sequence_data = array_map($entry_subset, $KEEP_SOURCE_FIELDS);
+        array_unshift($sequence_data, $sequence_count_total, $sequence_file);
+        fputcsv($sequence_data_handle, $sequence_data, $SEQUENCE_DATA_DELIMITER);
+    } // end while loop
+    fclose($source_handle);
+    fclose($sequence_cache_handle);
+    fclose($sequence_data_handle);
+
+    if ($sequence_count_total == 0) {
+        echo('No sequences were downloaded. Bad taxon name?' . PHP_EOL);
+        return array(true, false);
+    }
+
+    // Save data in a csv
+
+    $taxsets_handle = fopen($taxsets_data_file, 'w'); // truncates
+
+    // make header
+    $header = array(
+        field::TAXON,
+        field::DIVISION_SCHEME,
+        field::LOCATION,
+        field::COUNT,
+        field::FILE,
+        field::TAXSET
+    );
+    fputcsv($taxsets_handle, $header, $TAXSETS_DATA_DELIMITER);
+
+    // Store entries
+    foreach ($sequence_counts as $loc => $count)
+    {
+        $entry = array(
+            $taxon,
+            division_scheme(),
+            $loc,
+            $count,
+            $sequence_file,
+            $taxsets[$loc]
+        );
+        fputcsv($taxsets_handle, $entry, $TAXSETS_DATA_DELIMITER);
+    }
+    fclose($taxsets_handle);
+
+    return array(true, $taxsets_data_file);
+
+} //  end function get_sequences
+
+?>

--- a/make_trees.php
+++ b/make_trees.php
@@ -1,0 +1,64 @@
+<?php
+
+// Calculates trees for input aligned samples of sequences.
+// $data is a string in NEXUS format specifying sequences and taxsets of aligned sequences.
+// $taxset_names is an array of strings which name taxsets set in $data.
+// Outputs a single NEXUS file of multiple TREE blocks to $tre_filename.
+function make_trees($data, $tree_names, $tre_filename) {
+	global $PAUP_PATH, $PAUP_COMMANDS_SETUP, $PAUP_COMMANDS_TREE, $PAUP_COMMANDS_END;
+	global $TEMP_DIR, $LOG_DIR;
+
+	$TREE_DECLARATION_REGEX = "/tree\s+'[^']*'\s*=/i";
+	$DATA_BLOCK_REGEX = '/matrix\s*[^;]*;\s*end\s*;/is';
+
+	if (!file_exists($PAUP_COMMANDS_SETUP)) { return false; }
+	$paup_setup = file_get_contents($PAUP_COMMANDS_SETUP);
+
+	$nexus_string = '#NEXUS' . PHP_EOL;
+	if (substr($data, 0, strlen($nexus_string)) == $nexus_string) {
+		$nexus = substr_replace($data, $nexus_string . $paup_setup . PHP_EOL, 0, strlen($nexus_string));
+	} else {
+		$nexus = $paup_setup . $data;
+	}
+
+	if (!file_exists($PAUP_COMMANDS_TREE)) { return false; }
+	$paup_maketree = file_get_contents($PAUP_COMMANDS_TREE);
+
+	$append_script = function ($match) use ($paup_maketree) { 
+		return $match[0] .PHP_EOL. $paup_maketree .PHP_EOL; 
+	};
+	$nexus = preg_replace_callback($DATA_BLOCK_REGEX, $append_script, $nexus);
+	
+	if (!file_exists($PAUP_COMMANDS_END)) { return false; }
+	$nexus .= file_get_contents($PAUP_COMMANDS_END);
+
+	do {
+		$nex_id = uniqid('paup');
+		$nex_filename_base = $TEMP_DIR . $nex_id;
+		$nex_filename = $nex_filename_base . '.nex';
+	} while (file_exists($nex_filename));
+	file_put_contents($nex_filename, $nexus);
+
+	// Run PAUP
+	$command =  $PAUP_PATH . ' ' . $nex_filename .  " 1>" . $LOG_DIR . $nex_id .'.log';
+	system($command);
+
+	$tre_temp_name = $nex_filename_base . '.tre';
+	if (file_exists($tre_temp_name)) {
+		rename($tre_temp_name, $tre_filename);
+
+		// Rename the trees
+		$tree_list = file_get_contents($tre_filename);
+		$i = 0;
+		$rename_tree = function ($s) use ($tree_names, &$i) { 
+			$decl = "tree '".$tree_names[$i]."' =";
+			$i++;
+			return $decl; };
+		$tree_list = preg_replace_callback($TREE_DECLARATION_REGEX, $rename_tree, $tree_list);
+		file_put_contents($tre_filename, $tree_list);
+	}
+
+	// cleanup
+}
+
+?>

--- a/paup_commands_end.txt
+++ b/paup_commands_end.txt
@@ -1,0 +1,4 @@
+[PAUP block]
+begin paup;
+    quit;
+end;

--- a/paup_commands_setup.txt
+++ b/paup_commands_setup.txt
@@ -1,0 +1,9 @@
+[PAUP block]
+begin paup;
+    set autoclose=yes warntree=no warnreset=no;
+    [root trees at midpoint]
+    set rootmethod=midpoint;
+    set outroot=monophyl;
+    [ensure branch lengths are output as substituions per nucleotide]
+    set criterion=distance;
+end;

--- a/paup_commands_tree.txt
+++ b/paup_commands_tree.txt
@@ -1,0 +1,7 @@
+[PAUP block]
+begin paup;
+    [construct tree using neighbour-joining]
+    nj;
+    [write rooted trees in Newick format with branch lengths]
+    savetrees format=nexus root=yes brlen=yes append=yes;
+end;

--- a/phylodiv.php
+++ b/phylodiv.php
@@ -2,10 +2,22 @@
 
 
 $WINDOWS = (stripos(PHP_OS, 'WIN') === 0);
+$DIR = __DIR__ . DIRECTORY_SEPARATOR ;
 
-// Default arguments and constants
+require_once $DIR. 'get_sequences.php';
+require_once $DIR. 'subsample_and_align.php';
+require_once $DIR. 'geo_divisions.php';
+require_once $DIR. 'division_scheme.php';
+require_once $DIR. 'geo_divide.php';
+require_once $DIR. 'make_trees.php';
+require_once $DIR. 'tree_lengths.php';
 
-$SAMPLE_NUMBER = 20;
+// Default arguments
+
+$SUBSAMPLE_NUMBER = 10;
+
+$LATITUDE_GRID_SIZE_DEG = 30;
+$LONGITUDE_GRID_SIZE_DEG = 30;
 
 $CLUSTAL_PATH = '/usr/local/bin/clustalw2';
 $PAUP_PATH = '/usr/local/bin/paup';
@@ -13,260 +25,90 @@ if ($WINDOWS) {
 	$CLUSTAL_PATH = '\\"Program Files (x86)"\\ClustalW2\\clustalw2';
 	$PAUP_PATH = '%appdata%\\PAUP4\\paup4';
 }
-$PAUP_COMMANDS_PATH = __DIR__ .DIRECTORY_SEPARATOR. 'paup_commands_template.txt';
 
+// Constants
+
+$GEO_DIVISION_SCHEMES = array_flip(array('COORDS','COUNTRY'));
+$GEO_DIVISION_SCHEME = $GEO_DIVISION_SCHEMES['COORDS'];
+
+$PAUP_COMMANDS_SETUP = $DIR. 'paup_commands_setup.txt';
+$PAUP_COMMANDS_TREE = $DIR. 'paup_commands_tree.txt';
+$PAUP_COMMANDS_END = $DIR. 'paup_commands_end.txt';
+
+$MINIMUM_SUBSAMPLE_NUMBER = 3; // need at least 3 taxa to build trees
 $MARKER = 'COI-5P';
 $USE_COORDS = true;
-$LATITUDE_GRID_SIZE_DEG = 30;
-$LONGITUDE_GRID_SIZE_DEG = 30;
 
-// Function for dividing up location data into key strings
-function location_string($country, $lat, $lon) {
-	global $USE_COORDS, $LATITUDE_GRID_SIZE_DEG, $LONGITUDE_GRID_SIZE_DEG;
-
-	if ($USE_COORDS)
-	{
-		$lat_a = floor($lat / $LATITUDE_GRID_SIZE_DEG) * $LATITUDE_GRID_SIZE_DEG;
-		$lat_b = $lat_a + $LATITUDE_GRID_SIZE_DEG;
-		$grid_lat = $lat_a . 'to' . $lat_b;
-		$lon_a = floor($lon / $LONGITUDE_GRID_SIZE_DEG) * $LONGITUDE_GRID_SIZE_DEG;
-		$lon_b = $lon_a + $LONGITUDE_GRID_SIZE_DEG;
-		$grid_lon = $lon_a . 'to' . $lon_b;
-		return 'lat_' . $grid_lat . '_lon_' . $grid_lon;
-	} else {
-		return $country;
-	}
+class field
+{
+	const TAXON = 'taxon';
+	const DIVISION_SCHEME = 'division_scheme';
+	const LOCATION = 'location';
+	const COUNT = 'count';
+	const FILE = 'file';
+	const TAXSET = 'taxset';
 }
+$TAXSETS_DATA_DELIMITER = ',';
+$TAXSET_DELIMITER = ' ';
+$SEQUENCE_DATA_DELIMITER = ',';
+
+$TEMP_DIR = getcwd() .DIRECTORY_SEPARATOR. 'temp' .DIRECTORY_SEPARATOR; 
+if (!is_dir($TEMP_DIR)) { mkdir($TEMP_DIR); }
+$LOG_DIR = getcwd() .DIRECTORY_SEPARATOR. 'logs' .DIRECTORY_SEPARATOR;
+if (!is_dir($LOG_DIR)) { mkdir($LOG_DIR); }
+$SEQUENCES_DIR = getcwd() .DIRECTORY_SEPARATOR. 'sequences' .DIRECTORY_SEPARATOR;
+if (!is_dir($SEQUENCES_DIR)) { mkdir($SEQUENCES_DIR); }
+
+// Get command line arguments
 
 $args = array(
 	'SCRIPT_PATH',
-	'taxon_group',
-	'SAMPLE_NUMBER',
+	'taxon',
+	'SUBSAMPLE_NUMBER',
 	'LATITUDE_GRID_SIZE_DEG',
 	'LONGITUDE_GRID_SIZE_DEG',
 	'CLUSTAL_PATH',
 	'PAUP_PATH');
 
-if(!isset($argc)) {exit("argc and argv disabled");}
-if($argc > count($args)) { exit("Wrong number of arguments given");}
-if(!($i = $argc - 1)) {exit("No arguments given");}
+if(!isset($argc)) { exit("argc and argv disabled"); }
+if($argc > count($args)) { exit("Wrong number of arguments given"); }
+if(!($i = $argc - 1)) { exit("No arguments given"); }
 
 while($i) {
 	${$args[$i]} = $argv[$i];
-	echo('set '. $args[$i] . ' to ' . $argv[$i] . PHP_EOL);
+	// echo('set '. $args[$i] . ' to ' . $argv[$i] . PHP_EOL);
 	$i--;
 }
 
-// Set up paths to sequences
+// Get sequences, subsample, align, and build trees
 
-$SEQUENCES_FOLDER = getcwd() . DIRECTORY_SEPARATOR . $taxon_group . '_sequences';
-if(!is_dir($SEQUENCES_FOLDER)) {mkdir($SEQUENCES_FOLDER);}
-$SEQUENCES_PATH = $SEQUENCES_FOLDER . DIRECTORY_SEPARATOR;
-$SEQUENCES_LIST_FILE_DELIMITER = ',';
-
-$sequences_list_file = $taxon_group . '_sequences.csv';
-
-function sequence_file($location) {
-	global $SEQUENCES_PATH;
-	return $SEQUENCES_PATH . $location . '.fas';
+[$download_attempted, $taxsets_data_file] = get_sequences($taxon, $MARKER);
+if (!$taxsets_data_file) {
+	exit ('No sequences for '.$taxon.' found locally or on BOLD.');
 }
 
-
-// Functions to do the alignment and tree work
-
-function align($infile) {
-	global $CLUSTAL_PATH;
-
-	$command = $CLUSTAL_PATH 
-	. ' -INFILE=' . $infile 
-	. ' -QUICKTREE -OUTORDER=INPUT -OUTPUT=NEXUS' 
-	. " 1>" . $basename . '_CLUSTALW.log';
-	system($command);
-
-	$outfile = preg_replace('/\.fas/i', '.nxs', $infile);
-	$outfile_ = preg_replace('/_sample/i', '', $outfile);
-	if(rename($outfile, $outfile_)) {
-		return $outfile_;
-	}
+if (!$download_attempted) {
+	echo ('Found saved data file for ' . $taxon . '.'.PHP_EOL);
 }
 
-function make_tree($infile) {
-	global $PAUP_PATH;
-
-	// First build the nexus file of commands
-	$nexus = file_get_contents($infile) . PHP_EOL . file_get_contents($PAUP_COMMANDS_PATH);
-
-	$basename = preg_replace('/\..*$/', '', $infile);
-	$nex_filename = $basename . '.nex';
-	file_put_contents($nex_filename, $nexus);
-
-	// Run PAUP
-	$command =  $PAUP_PATH . ' ' . $nex_filename .  " 1>" . $basename . '_PAUP.log';
-
-	system($command);
-
-	if(file_exists($basename . '.tre')) {
-		return $basename . '.tre';
+$geo_divisions = geo_divisions($taxon);
+if ($lc = count($geo_divisions)) {
+	if ($download_attempted) {
+		echo ('Sorted downloaded sequences into '.$lc.' locations according to '. division_scheme().'.' .PHP_EOL);
+	} else {
+		echo ('Found sorting of sequences into '.$lc.' locations according to '. division_scheme().'.' .PHP_EOL);
 	}
-}
-
-function tree_length($tree_filename) {
-	$tree = file_get_contents($tree_filename);
-
-	// Find Newick tree within file
-	$tree_regex = '/\s*tree\s+\'.*\'\s+=.*;/i';
-	preg_match($tree_regex, $tree, $tree_line);
-	if(!count($tree_line)) {
-		exit('Tree not found in output file!');
-	}
-
-	// Get branch lengths array e.g. ((":0.0938", ":0.0013")) etc and sum them
-	$branch_length_regex = '/:\d+[\.,]?\d*/';
-	preg_match_all($branch_length_regex, $tree_line[0], $branch_lengths);
-	if(!count($branch_lengths[0])) {
-		exit('No branch lengths in tree!');
-	}
-
-	$sum = 0;
-	foreach ($branch_lengths[0] as $len)
-	{
-		$sum += substr($len, 1); // first char is ':'
-	}
-	return $sum;
-}
-
-// First get hold of the sequences, if they're not downloaded already
-
-// TODO #4 the sequences should only be downloaded once for potentially different geographical division schemes
-if(!file_exists($sequences_list_file)) {
-	echo('List of sequence files not found, downloading sequences for ' . $taxon_group . PHP_EOL);
-
-	// Open stream handle
-	$bold_query = 'http://www.boldsystems.org/index.php/API_Public/combined?' . 
-		'format=tsv&marker=' . $MARKER . '&taxon=' . $taxon_group;	
-	$source_handle = fopen($bold_query, 'r');
-
-	// Get header for indexing columns
-	$tsv = array_flip(fgetcsv($source_handle, 0, "\t"));
-
-	$locations = array();
-	$sequence_counts = array();
-	$sequence_count_total = 0;
-
-	// Step through stream line by line
-	while ($fields = fgetcsv($source_handle, 0, "\t"))
-	{
-		// Check marker is the one we want to use
-		if($fields[$tsv['markercode']] != $MARKER) {continue;}
-
-		// Check location is present: either coordinates or country
-		if($USE_COORDS) {
-			if(($lat = $fields[$tsv['lat']]) == '') {continue;}
-			if(($lon = $fields[$tsv['lon']]) == '') {continue;}
-		} else {
-			if(($country = $fields[$tsv['country']]) == '') {continue;}
-		}
-		$loc = location_string($country, $lat, $lon);
-
-		// Get handle to sequence file if not open yet
-		if(!array_key_exists($loc, $locations)) {
-			$locations[$loc] = fopen(sequence_file($loc), 'w');
-		}
-
-		// Make sequence header
-		if (($id = $fields[$tsv['processid']]) == '') {continue;}
-		$id = preg_replace('/-/', '_', $id);
-		if (($species = $fields[$tsv['species_name']]) != '') {
-			$sequence_header = preg_replace('/[- ]/', '_', $species) . '|' . $id;
-		} else if (($genus = $fields[$tsv['genus_name']]) != '') {
-			$sequence_header = $genus . '_sp|' . $id;
-		} else {
-			$sequence_header = $id;
-		}
-		$sequence_header = '>' . $sequence_header . PHP_EOL;
-
-		// Get sequence and write to file after header
-		if (($seq = $fields[$tsv['nucleotides']]) == '') {continue;}
-		fwrite($locations[$loc], $sequence_header);
-		fwrite($locations[$loc], $seq . PHP_EOL);
-
-		$sequence_counts[$loc]++;
-		$sequence_count_total++;
-		if($sequence_count_total % 500 == 0) {
-			echo("Saved " . $sequence_count_total . ' sequences...' . PHP_EOL);
-		}
-	}
-
-	// Close all open files, and save the paths and sequence counts as csv
-	$list_handle = fopen($sequences_list_file, 'w');
-	fwrite($list_handle, 
-		'location' . $SEQUENCES_LIST_FILE_DELIMITER
-		. 'path' . $SEQUENCES_LIST_FILE_DELIMITER
-		. 'count' . PHP_EOL);
-	foreach ($locations as $loc => $handle)
-	{
-		fclose($handle);
-		fwrite($list_handle, 
-			$loc . $SEQUENCES_LIST_FILE_DELIMITER 
-			. sequence_file($loc) . $SEQUENCES_LIST_FILE_DELIMITER
-			. $sequence_counts[$loc] . PHP_EOL);
-	}
-	fclose($list_handle);
-	fclose($source_handle);
 } else {
-	echo('List of sequence files found for ' . $taxon_group . PHP_EOL);
+	echo ('Sorting sequences into location according to ' . division_scheme() . '...' . PHP_EOL);
+	$geo_divisions = geo_divide($taxon);
 }
 
-// Next, create samples and build trees.
+echo ('Creating and aligning subsamples of size '.$SUBSAMPLE_NUMBER.'...'.PHP_EOL);
+$aligned_subsamples = subsample_and_align($SUBSAMPLE_NUMBER, $taxon, $geo_divisions);
 
-// For each file of sequences listed in sequences_list_file,
-$list_handle = fopen($sequences_list_file, 'r');
-$col = array_flip(fgetcsv($list_handle));
-while($loc = fgetcsv($list_handle))
-{
-	// Check that there are enough sequences to sample
-	if(($seq_count = $loc[$col['count']]) <= $SAMPLE_NUMBER) {
-		echo('Location ' . $loc[$col['location']] . ' is too small to sample.' . PHP_EOL);
-		continue;
-	}
-
-	// Generate SAMPLE_NUMBER random numbers between 0 and sequence count
-	$sample_indices = array();
-	for ($i = 0; $i < $SAMPLE_NUMBER; $i++)	{
-		do {
-			$r = mt_rand(0, $seq_count- 1);
-		} while (in_array($r, $sample_indices));
-		array_push($sample_indices, $r);
-	}
-
-	// Go through the file and copy the sequences occurring at those indices into a sample file
-	$sequence_file_path = $loc[$col['path']];
-	$sequence_file = fopen($sequence_file_path, 'r');
-	$sample_file_path = preg_replace('/\.fas/i', '_sample.fas', $sequence_file_path);
-	$sample_file = fopen($sample_file_path, 'w');
-
-	echo('Sampling sequences from ' . $sequence_file_path . PHP_EOL);
-
-	$i = -1;
-	while($line = fgets($sequence_file)) {
-
-		if(preg_match('/\>/', $line)){
-			// header
-			$i++;
-		}
-		if(in_array($i, $sample_indices)) {
-			fwrite($sample_file, $line);
-		}
-	}
-	fclose($sample_file);
-	fclose($sequence_file);
-
-
-	// Now align and generate a tree for this taxon
-	echo('Making alignment and tree from ' . $sample_file_path . PHP_EOL);
-	$tree = make_tree(align($sample_file_path));
-	echo('Tree branch sum: ' . tree_length($tree) . PHP_EOL);
-
-}
+$tree_file = $taxon . '.tre';
+make_trees($aligned_subsamples, $geo_divisions, $tree_file);
+echo('Tree lengths for location samples: '.PHP_EOL);
+print_r(tree_lengths($tree_file));
 
 ?>

--- a/sequence_data_file.php
+++ b/sequence_data_file.php
@@ -1,0 +1,10 @@
+<?php
+
+function sequence_data_file($taxon) {
+    global $SEQUENCES_DIR;
+
+    return $SEQUENCES_DIR . $taxon . '_seq_data.csv';
+
+}
+
+?>

--- a/sequence_file.php
+++ b/sequence_file.php
@@ -1,0 +1,9 @@
+<?php
+
+function sequence_file($taxon) {
+    global $SEQUENCES_DIR;
+
+    return $SEQUENCES_DIR . $taxon . '_sequences.fas';
+}
+
+?>

--- a/subsample_and_align.php
+++ b/subsample_and_align.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once $DIR. 'subsample_taxsets.php';
+require_once $DIR. 'align.php';
+require_once $DIR. 'taxsets_data_file.php';
+
+
+// Picks subsamples of $subsample_size from groups of sequences listed in given data file, aligns them,
+// and outputs a string in NEXUS format consisting of aligned sequences in separate DATA blocks.
+// Outputs a warning if any of the subsampled sequences are missing from the file they should be in,
+// or if any samples are of size 1 and so cannot be aligned.
+function subsample_and_align($subsample_size, $taxon, $taxset_locations) {
+    global $MINIMUM_SUBSAMPLE_NUMBER, $LOG_DIR;
+	global $TAXSETS_DATA_DELIMITER, $TAXSET_DELIMITER;
+
+    $CLUSTAL_LOG_SUFFIX = '_CLUSTALW.log';
+
+    if ($subsample_size < $MINIMUM_SUBSAMPLE_NUMBER) { return ''; }
+
+    // Get the columns from the data file
+    $taxsets_data_handle = fopen(taxsets_data_file($taxon), 'r');
+    $col = array_flip(fgetcsv($taxsets_data_handle, 0, $TAXSETS_DATA_DELIMITER));
+
+    $nexus_string = '#NEXUS' . PHP_EOL;
+    $file_offset = strlen($nexus_string);
+
+    $taxon_number = 0;
+    $taxset_names = array();
+
+    // Go through all entries
+    while ($entry = fgetcsv($taxsets_data_handle, 0, $TAXSETS_DATA_DELIMITER)) {
+
+        $sequence_file = $entry[$col[field::FILE]];
+        $taxset_str = $entry[$col[field::TAXSET]];
+        $location = $entry[$col[field::LOCATION]];
+
+        if (!in_array($location, $taxset_locations)) { continue; }
+
+        if (count(explode($TAXSET_DELIMITER, $taxset_str)) < $MINIMUM_SUBSAMPLE_NUMBER) {
+            continue;
+        }
+
+        // Do the subsampling
+        [$subsample_id, $subsample_file, $subsample_taxset]
+            = subsample_taxsets($subsample_size, $taxset_str, $TAXSET_DELIMITER, $sequence_file);
+        if ($subsample_taxset === '') { 
+            echo('Sequences missing from subsample ' . $subsample_id . PHP_EOL);
+            continue; 
+        }
+        
+        // Align the subsample
+        $alignment_log_file = $LOG_DIR . $subsample_id . $CLUSTAL_LOG_SUFFIX;
+        $subsample_file_aligned = align($subsample_file, $alignment_log_file);
+
+        if ($subsample_file_aligned === '') {
+            echo('Alignment failed for subsample ' . $subsample_id . PHP_EOL);
+            continue;
+        }
+
+        $nexus_string .= file_get_contents($subsample_file_aligned, 0, NULL, $file_offset);
+
+        continue;
+
+        // Add a taxset string for the sample
+        // Since we're storing multiple taxsets in the same file, add an offset of $taxon_number
+        $taxset = explode($TAXSET_DELIMITER, $subsample_taxset);
+        $current_subsample_size = count($taxset);
+        $taxset = range($taxon_number + 1, $taxon_number + $current_subsample_size);
+        $subsample_taxset = implode($TAXSET_DELIMITER, $taxset);
+
+        $nexus_string .= 
+'
+BEGIN ASSUMPTIONS;
+    taxset ' . $subsample_id . ' = ' . $subsample_taxset . ';
+end;
+';
+
+        $taxon_number += count($taxset);
+        array_push($taxset_names, $subsample_id);
+    }
+
+    return $nexus_string;
+}
+
+?>

--- a/subsample_taxsets.php
+++ b/subsample_taxsets.php
@@ -1,0 +1,59 @@
+<?php
+
+// Subamples $subsample_size sequences from a given taxset string of sequence indices.
+// $taxsets_str should be indices at which sequences are found in FASTA format in $sequence_file.
+// These indices start at 1, and are separated by $taxset_delimiter.
+// Returns an array of form { SUBSAMPLE_ID_NO, SUBSAMPLE_FILE_PATH, SUBSAMPLE_TAXSET_STRING },
+// or { '', '', '' } if any sequences in the subsample are missing from $sequence_file.
+// If there are less than $subsample_size taxa in $taxset_str, then it will be used without sampling to fetch sequences.
+function subsample_taxsets($subsample_size, $taxset_str, $taxset_delimiter, $sequence_file) {
+    global $TEMP_DIR;
+    
+    $taxset = explode($taxset_delimiter, $taxset_str);
+
+    // Use the taxset as the sample if it's too small; otherwise, pick random taxa from it
+	if(count($taxset) <= $subsample_size) {
+        $subsample = $taxset;
+        $subsample_str = $taxset_str;
+        $subsample_size = count($taxset);
+    } else {
+        $subsample = array_rand(array_flip($taxset), $subsample_size);
+        $subsample_str = implode($taxset_delimiter, $subsample);
+    }
+
+    // Get handle to a new, arbitrarily-named temp file for storing the sample sequences
+    do {
+        $subsample_id = uniqid('s');
+        $subsample_file = $TEMP_DIR . $subsample_id . '.fas';
+    } while (file_exists($subsample_file));
+	$subsamples_handle = fopen($subsample_file, 'w');
+
+    $i = 0; // note: taxset indices start at 1, not 0. So increment this BEFORE checking whether to sample.
+    $subsampled_count = 0;
+    $sequences_handle = fopen($sequence_file, 'r');
+
+    // Go through the sequences and copy lines at sampled indices
+	while($line = fgets($sequences_handle)) {
+
+		if((trim($line)[0] == '>')){
+			$header = true;
+			$i++;
+        } else { $header = false; }
+
+		if(in_array($i, $subsample)) {
+            fwrite($subsamples_handle, $line);
+            if ($header) { $subsampled_count++; }
+		}
+	}
+	fclose($subsamples_handle);
+	fclose($sequences_handle);
+
+    if ($subsampled_count < $subsample_size) {
+        // something was missing!
+        return array('','','');
+    }
+
+    return array($subsample_id, $subsample_file, $subsample_str);
+}
+
+?>

--- a/taxsets_data_file.php
+++ b/taxsets_data_file.php
@@ -1,0 +1,8 @@
+<?php
+
+// Gets the path to a file for storing data relating to geographical taxsets of a given taxon.
+function taxsets_data_file($taxon) {
+    return  getcwd() . DIRECTORY_SEPARATOR . $taxon . '_sets.csv';
+}
+
+?>

--- a/tree_lengths.php
+++ b/tree_lengths.php
@@ -1,0 +1,37 @@
+<?php
+
+function tree_lengths($tree_filename) {
+	$tree = file_get_contents($tree_filename);
+
+	$TREE_REGEX = "/\s*tree\s+'[^']*'\s*=[^;]*;/i";
+	$BRANCH_LENGTH_REGEX = '/:\d+[\.,]?\d*/';
+
+	// Find Newick trees within file
+	if(!preg_match_all($TREE_REGEX, $tree, $tree_lines)) {
+		echo('Trees not found in file ' . $tree_filename . PHP_EOL);
+		return array();
+	}
+
+	// Get branch lengths array e.g. ((":0.0938", ":0.0013")) etc and sum them
+	$tree_lengths = array();
+
+	foreach ($tree_lines[0] as $tree_line)
+	{
+		preg_match_all($BRANCH_LENGTH_REGEX, $tree_line, $branch_lengths);
+		if(!count($branch_lengths[0])) {
+			echo('Branch lengths missing from Newick tree in ' . $tree_filename . PHP_EOL);
+			continue;
+		}
+
+		$sum = 0;
+		foreach ($branch_lengths[0] as $len)
+		{
+			$sum += floatval(substr($len, 1)); // first char is ':'
+		}
+		$tree_name = explode("'", $tree_line)[1];
+		$tree_lengths[$tree_name] = $sum;
+	}
+	return $tree_lengths;
+}
+
+?>


### PR DESCRIPTION
 - Split most program structure into different functions, put those functions in separate files
 - Program now downloads sequences only once per taxonomic group, puts them all into one local cache
 - Also caches location data for each sequence, for future use in different geographical division schemes
 - Geographical division now works as intended: any nonzero amount of degrees can be passed in, and if that geographical scheme hasn't been used before, the progam will calculate a new subset of the total cached sequences.
 - Lots of temp files generated, need to clean those up